### PR TITLE
Fix "jobsEmojiList" not defined

### DIFF
--- a/public/home/js/icons.js
+++ b/public/home/js/icons.js
@@ -1,3 +1,4 @@
+const emojiFolder = "/home/images/openmoji/";
 const customEmojiFolder = "/home/images/companyemoji/";
 
 const jobsEmojiList = {

--- a/public/home/js/icons.js
+++ b/public/home/js/icons.js
@@ -1,3 +1,5 @@
+const customEmojiFolder = "/home/images/companyemoji/";
+
 const jobsEmojiList = {
     "conductor": "🚂",
     "busdriver": "🚌",

--- a/public/home/js/map.js
+++ b/public/home/js/map.js
@@ -1,4 +1,3 @@
-const emojiFolder = "/home/images/openmoji/";
 const mapFolder = "/home/images/maps/";
 
 var serversList = [

--- a/public/home/js/map.js
+++ b/public/home/js/map.js
@@ -1,6 +1,5 @@
 const emojiFolder = "/home/images/openmoji/";
 const mapFolder = "/home/images/maps/";
-const customEmojiFolder = "/home/images/companyemoji/";
 
 var serversList = [
     ["tycoon-w8r4q4.users.cfx.re","OS", "OS"],


### PR DESCRIPTION
Moved "customEmojiFolder" variable from map.js to icons.js, since icons.js loads first, and requires the variable to be defined to initialize the jobs list array.